### PR TITLE
Get rid of `--platform`, switch to `openjdk:8-jre-slim`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM --platform=$BUILDPLATFORM openjdk:8-jdk-slim AS builder
+FROM openjdk:8-jdk-slim AS builder
 COPY . /
 RUN ./gradlew --no-daemon distTar
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre-slim
 COPY --from=builder /app/build/distributions/healthchek.tar .
 RUN tar -xf healthchek.tar
 ENTRYPOINT ["/healthchek/bin/healthchek"]


### PR DESCRIPTION
This PR introduces the following changes:

- Get rid of (experimental) `--platform=$BUILDPLATFORM` parameter in `Dockerfile`, so now it's possible to build container images (locally) with `docker build`. It ain't affect multi-arch Cloud builds.
- Switch to Debian-based `openjdk:8-jre-slim` as a base image. Alpine based had some problems on M1