### PR TITLE
Add network and db utility tools to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,33 @@ RUN ./gradlew --no-daemon distTar
 FROM openjdk:8-jre-alpine
 COPY --from=builder /app/build/distributions/healthchek.tar .
 RUN tar -xf healthchek.tar
+
+RUN apk add busybox-extras tcpdump iptables bind-tools ngrep postgresql netcat-openbsd nmap
+
+# MSSQL_VERSION can be changed, by passing `--build-arg MSSQL_VERSION=<new version>` during docker build
+ARG MSSQL_VERSION=17.5.2.1-1
+ENV MSSQL_VERSION=${MSSQL_VERSION}
+
+WORKDIR /tmp
+# Installing system utilities
+RUN apk add --no-cache curl gnupg --virtual .build-dependencies -- && \
+    # Adding custom MS repository for mssql-tools and msodbcsql
+    curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_${MSSQL_VERSION}_amd64.apk && \
+    curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_${MSSQL_VERSION}_amd64.apk && \
+    # Verifying signature
+    curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_${MSSQL_VERSION}_amd64.sig && \
+    curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_${MSSQL_VERSION}_amd64.sig && \
+    # Importing gpg key
+    curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import - && \
+    gpg --verify msodbcsql17_${MSSQL_VERSION}_amd64.sig msodbcsql17_${MSSQL_VERSION}_amd64.apk && \
+    gpg --verify mssql-tools_${MSSQL_VERSION}_amd64.sig mssql-tools_${MSSQL_VERSION}_amd64.apk && \
+    # Installing packages
+    echo y | apk add --allow-untrusted msodbcsql17_${MSSQL_VERSION}_amd64.apk mssql-tools_${MSSQL_VERSION}_amd64.apk && \
+    # Deleting packages
+    apk del .build-dependencies && rm -f msodbcsql*.sig mssql-tools*.apk
+
+WORKDIR /
+# Adding SQL Server tools to $PATH
+ENV PATH=$PATH:/opt/mssql-tools/bin
+
 ENTRYPOINT ["/healthchek/bin/healthchek"]


### PR DESCRIPTION
Adds a set of network utilities and DB utilities to the image. The intent is they can be used to diagnose and resolve connectivity issues similar to the network conditions used by the other containers.

The tools it adds include:
telnet, ping, tcpdump, ngrep, dig, nslookup, netstat, route, nmap, traceroute, iptables, netcat and psql

I tested the resulting image and the healthchek still works:

```
❯ docker container run -it --rm gcr.io/tidal-1529434400027:latest https://google.com 200                                                                                                                                                                                                                                                     
OK
```