### PR TITLE
WIP add oracle client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,27 @@ WORKDIR /
 # Adding SQL Server tools to $PATH
 ENV PATH=$PATH:/opt/mssql-tools/bin
 
+# Oracle client
+ENV LD_LIBRARY_PATH=/lib
+
+ARG ORACLE_INSTALLER=instantclient-basic-linux.x64-21.3.0.0.0.zip
+RUN wget https://download.oracle.com/otn_software/linux/instantclient/213000/${ORACLE_INSTALLER} && \
+    unzip ${ORACLE_INSTALLER} && \
+    cp -r instantclient_21_3/* /lib && \
+    rm -rf ${ORACLE_INSTALLER} && \
+    apk add libaio && \
+    apk add libaio libnsl libc6-compat
+    cd /lib && \
+    ln -s /lib64/* /lib && \
+    ln -s libc.so.6 /lib/libresolv.so.2
+
+ARG SQLPLUS_INSTALLER=instantclient-sqlplus-linux.x64-21.3.0.0.0.zip
+
+RUN wget https://download.oracle.com/otn_software/linux/instantclient/213000/${SQLPLUS_INSTALLER} && \
+    unzip ${SQLPLUS_INSTALLER} && \
+    cp -r instantclient_21_3/* /lib && \
+    rm -rf ${SQLPLUS_INSTALLER}
+
+ENV PATH=$PATH:/lib
+
 ENTRYPOINT ["/healthchek/bin/healthchek"]


### PR DESCRIPTION
Currently not working.

sources for installing are here - https://www.oracle.com/database/technologies/instant-client/linux-x86-64-downloads.html#ic_x64_inst

and inspired by this here - https://github.com/Shrinidhikulkarni7/OracleClient_Alpine/blob/master/Dockerfile

hitting this error when trying to use sqplus

```
/lib # sqlplus 
Error relocating /lib/libclntsh.so.21.1: __printf_chk: symbol not found
Error relocating /lib/libclntsh.so.21.1: canonicalize_file_name: symbol not found
Error relocating /lib/libclntsh.so.21.1: getcontext: symbol not found
Error relocating /lib/libclntsh.so.21.1: __res_nsearch: symbol not found
Error relocating /lib/libclntsh.so.21.1: bindresvport: symbol not found
Error relocating /lib/libclntsh.so.21.1: __vsprintf_chk: symbol not found
Error relocating /lib/libclntsh.so.21.1: __dn_skipname: symbol not found
Error relocating /lib/libclntsh.so.21.1: backtrace: symbol not found
Error relocating /lib/libclntsh.so.21.1: backtrace_symbols: symbol not found
Error relocating /lib/libclntsh.so.21.1: __finite: symbol not found
Error relocating /lib/libclntsh.so.21.1: __fprintf_chk: symbol not found
Error relocating /lib/libclntsh.so.21.1: __res_nclose: symbol not found
Error relocating /lib/libclntsh.so.21.1: __res_ninit: symbol not found
Error relocating /lib/libclntsh.so.21.1: secure_getenv: symbol not found
Error relocating /lib/libclntshcore.so.21.1: __printf_chk: symbol not found
Error relocating /lib/libclntshcore.so.21.1: __fprintf_chk: symbol not found
Error relocating /lib/libclntshcore.so.21.1: __vsprintf_chk: symbol not found
Error relocating /lib/libnnz21.so: backtrace: symbol not found
Error relocating /lib/libnnz21.so: backtrace_symbols: symbol not found
Error relocating /lib/sqlplus: __printf_chk: symbol not found
Error relocating /lib/sqlplus: __strncat_chk: symbol not found
Error relocating /lib/sqlplus: __vsprintf_chk: symbol not found
Error relocating /lib/sqlplus: __fprintf_chk: symbol not found
```

Looks like its cause by a difference in the c library in alpline, `apline-glibc`
https://github.com/asg1612/alpine-oracle-instantclient/issues/1